### PR TITLE
Allow notification access based on permission

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -87,12 +87,6 @@ Route::middleware(['auth', 'role:admin|master'])->group(function () {
         Route::post('/{user}/toggle-2fa', 'toggle2FA')->name('toggle-2fa');
     });
 
-    Route::middleware('permission:notification-all')->group(function () {
-        Route::get('notifications', [NotificationController::class, 'index'])->name('notifications.index');
-        Route::get('notifications/create', [NotificationController::class, 'create'])->name('notifications.create');
-        Route::post('notifications/send', [NotificationController::class, 'store'])->name('notifications.send');
-    });
-
     Route::middleware('permission:audits-all')->group(function () {
         Route::get('audits', [AuditController::class, 'index'])->name('audits.index');
         Route::get('audits/{audit}', [AuditController::class, 'show'])->name('audits.show');
@@ -106,6 +100,12 @@ Route::middleware('auth')->group(function () {
     Route::post('notifications/mark-all-read', [NotificationController::class, 'markAllRead'])->name('notifications.markAllRead');
 
     Route::post('push-subscriptions', [PushSubscriptionController::class, 'store'])->name('push-subscriptions.store');
+});
+
+Route::middleware(['auth', 'permission:notification-all'])->group(function () {
+    Route::get('notifications', [NotificationController::class, 'index'])->name('notifications.index');
+    Route::get('notifications/create', [NotificationController::class, 'create'])->name('notifications.create');
+    Route::post('notifications/send', [NotificationController::class, 'store'])->name('notifications.send');
 });
 
 Route::middleware(['auth', 'restrict.system.access'])->group(function () {

--- a/tests/Feature/Notifications/NotificationAccessTest.php
+++ b/tests/Feature/Notifications/NotificationAccessTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Feature\Notifications;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class NotificationAccessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createPermission(): Permission
+    {
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        return Permission::firstOrCreate(['name' => 'notification-all']);
+    }
+
+    public function test_user_with_permission_can_access_notification_pages(): void
+    {
+        $this->createPermission();
+
+        $user = User::factory()->create();
+        $user->givePermissionTo('notification-all');
+
+        $this->actingAs($user)
+            ->get(route('notifications.index'))
+            ->assertOk();
+
+        $this->actingAs($user)
+            ->get(route('notifications.create'))
+            ->assertOk();
+    }
+
+    public function test_user_without_permission_cannot_access_notification_pages(): void
+    {
+        $this->createPermission();
+
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get(route('notifications.index'))
+            ->assertForbidden();
+
+        $this->actingAs($user)
+            ->get(route('notifications.create'))
+            ->assertForbidden();
+    }
+}


### PR DESCRIPTION
## Summary
- allow the notification routes to be accessed by any authenticated user that has the `notification-all` permission
- cover the new routing rules with feature tests for permitted and forbidden users

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68cdab53c1bc832086fea68374bd896b