### PR TITLE
Allow system management access by permission

### DIFF
--- a/app/Http/Middleware/RestrictSystemAccess.php
+++ b/app/Http/Middleware/RestrictSystemAccess.php
@@ -15,10 +15,24 @@ class RestrictSystemAccess
     {
         $user = auth()->user();
 
-        if (! $user || ! $user->hasAnyRole(['master'])) {
+        if (! $user) {
             abort(403, 'Acesso negado.');
         }
 
-        return $next($request);
+        if ($user->hasRole('master')) {
+            return $next($request);
+        }
+
+        $systemPermissions = [
+            'permissions-all',
+            'roles-all',
+            'menu-all',
+        ];
+
+        if ($user->hasAnyPermission($systemPermissions)) {
+            return $next($request);
+        }
+
+        abort(403, 'Acesso negado.');
     }
 }


### PR DESCRIPTION
## Summary
- allow authenticated users holding system management permissions to pass the RestrictSystemAccess middleware
- keep master role bypass while preventing unauthorized access

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68cdc08ef3088320895f433a4d18ca55