### PR TITLE
Fix profile password update and avatar upload

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -8,6 +8,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Redirect;
+use Illuminate\Support\Facades\Storage;
 use PragmaRX\Google2FA\Google2FA;
 use Illuminate\Support\Facades\Crypt;
 use BaconQrCode\Renderer\ImageRenderer;
@@ -60,15 +61,46 @@ class ProfileController extends Controller
      */
     public function update(ProfileUpdateRequest $request): RedirectResponse
     {
-        $request->user()->fill($request->validated());
+        $user = $request->user();
+        $data = $request->validated();
 
-        if ($request->user()->isDirty('email')) {
-            $request->user()->email_verified_at = null;
+        $user->fill([
+            'name' => $data['name'],
+            'email' => $data['email'],
+        ]);
+
+        if (!empty($data['password'])) {
+            $user->password = $data['password'];
         }
 
-        $request->user()->save();
+        if ($user->isDirty('email')) {
+            $user->email_verified_at = null;
+        }
 
-        return Redirect::route('profile.edit');
+        $user->save();
+
+        return Redirect::route('profile.edit')->with('status', 'profile-updated');
+    }
+
+    public function updateAvatar(Request $request): RedirectResponse
+    {
+        $user = $request->user();
+
+        $validated = $request->validate([
+            'avatar' => ['required', 'image', 'max:2048'],
+        ]);
+
+        if ($user->avatar_path) {
+            Storage::disk('public')->delete($user->avatar_path);
+        }
+
+        $path = $validated['avatar']->store('avatars', 'public');
+
+        $user->forceFill([
+            'avatar_path' => $path,
+        ])->save();
+
+        return Redirect::route('profile.edit')->with('status', 'avatar-updated');
     }
 
     /**

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -38,6 +38,7 @@ class HandleInertiaRequests extends Middleware
                 'email' => $request->user()->email,
                 'roles' => $request->user()->getRoleNames()->toArray(),
                 'permissions' => $request->user()->getAllPermissions()->pluck('name')->toArray(),
+                'avatar_url' => $request->user()->avatar_url,
             ] : null,
         ],
     ];

--- a/app/Http/Requests/ProfileUpdateRequest.php
+++ b/app/Http/Requests/ProfileUpdateRequest.php
@@ -5,6 +5,7 @@ namespace App\Http\Requests;
 use App\Models\User;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Password;
 
 class ProfileUpdateRequest extends FormRequest
 {
@@ -25,6 +26,17 @@ class ProfileUpdateRequest extends FormRequest
                 'max:255',
                 Rule::unique(User::class)->ignore($this->user()->id),
             ],
+            'current_password' => ['nullable', 'required_with:password', 'current_password'],
+            'password' => ['nullable', 'confirmed', Password::defaults()],
         ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'password' => $this->filled('password') ? $this->password : null,
+            'password_confirmation' => $this->filled('password_confirmation') ? $this->password_confirmation : null,
+            'current_password' => $this->filled('current_password') ? $this->current_password : null,
+        ]);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Minishlink\WebPush\Subscription;
 use Minishlink\WebPush\WebPush;
 use App\Models\PushSubscription;
+use Illuminate\Support\Facades\Storage;
 
 /**
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\PushSubscription> $pushSubscriptions
@@ -37,6 +38,7 @@ class User extends Authenticatable implements AuditableContract
         'google2fa_secret',
         'confirmed_2fa',
         'active',
+        'avatar_path',
     ];
 
     /**
@@ -72,6 +74,15 @@ class User extends Authenticatable implements AuditableContract
     public function pushSubscriptions(): HasMany
     {
         return $this->hasMany(PushSubscription::class);
+    }
+
+    public function getAvatarUrlAttribute(): string
+    {
+        if ($this->avatar_path) {
+            return Storage::disk('public')->url($this->avatar_path);
+        }
+
+        return 'https://ui-avatars.com/api/?name=' . urlencode($this->name ?? '');
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -13,7 +13,6 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Minishlink\WebPush\Subscription;
 use Minishlink\WebPush\WebPush;
 use App\Models\PushSubscription;
-use Illuminate\Support\Facades\Storage;
 
 /**
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\PushSubscription> $pushSubscriptions
@@ -79,7 +78,7 @@ class User extends Authenticatable implements AuditableContract
     public function getAvatarUrlAttribute(): string
     {
         if ($this->avatar_path) {
-            return Storage::disk('public')->url($this->avatar_path);
+            return asset('storage/'.$this->avatar_path);
         }
 
         return 'https://ui-avatars.com/api/?name=' . urlencode($this->name ?? '');

--- a/database/migrations/2025_06_09_000000_add_avatar_path_to_users_table.php
+++ b/database/migrations/2025_06_09_000000_add_avatar_path_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('avatar_path')->nullable()->after('password');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('avatar_path');
+        });
+    }
+};

--- a/resources/js/Components/AvatarUploader.vue
+++ b/resources/js/Components/AvatarUploader.vue
@@ -38,8 +38,7 @@ import { ref, computed } from 'vue'
 import { usePage, router as Inertia } from '@inertiajs/vue3'
 
 const props = defineProps({
-  src:    { type: String, default: '' },
-  userId: { type: [String, Number], required: true },
+  src: { type: String, default: '' },
 })
 const emit = defineEmits(['updated'])
 
@@ -69,14 +68,18 @@ function onFileChange(e) {
   formData.append('avatar', file)
 
   Inertia.post(
-    route('profile.updateAvatar', { user: props.userId }),
+    route('profile.updateAvatar'),
     formData,
     {
       preserveScroll: true,
       onSuccess: page => {
-        // recupera a URL nova do avatar e emite para o pai
         const newUrl = page.props.auth.user.avatar_url
         emit('updated', newUrl)
+      },
+      onFinish: () => {
+        if (fileInput.value) {
+          fileInput.value.value = ''
+        }
       },
     }
   )

--- a/resources/js/Layouts/AdminLayout.vue
+++ b/resources/js/Layouts/AdminLayout.vue
@@ -189,7 +189,7 @@ function defaultTextClass(groupName) {
           <span v-if="!sidebarCollapsed">{{ sidebarCollapsed ? 'Expandir menu' : 'Recolher menu' }}</span>
         </button>
         <div class="flex items-center justify-center">
-          <img class="h-8 w-8 rounded-full" :src="`https://ui-avatars.com/api/?name=${user.name}`" alt="Avatar">
+          <img class="h-8 w-8 rounded-full" :src="user.avatar_url" alt="Avatar">
           <div v-if="!sidebarCollapsed" class="ml-3 text-left">
             <p class="text-sm font-medium text-white">{{ user.name }}</p>
             <p class="text-xs text-blue-custom-400">View profile</p>
@@ -210,7 +210,7 @@ function defaultTextClass(groupName) {
           </button>
           <div class="relative">
             <button @click="dropdownOpen = !dropdownOpen" class="flex items-center space-x-2 focus:outline-none">
-              <img class="h-8 w-8 rounded-full" :src="`https://ui-avatars.com/api/?name=${user.name}`" alt="">
+              <img class="h-8 w-8 rounded-full" :src="user.avatar_url" alt="">
               <span class="hidden md:inline-block text-sm font-medium text-blue-custom-600 dark:text-blue-custom-200">{{ user.name }}</span>
               <i class="fas fa-chevron-down text-xs text-blue-custom-500"></i>
             </button>

--- a/resources/js/Pages/Profile/Partials/ProfileHeader.vue
+++ b/resources/js/Pages/Profile/Partials/ProfileHeader.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="flex items-center space-x-4">
     <AvatarUploader
-      :src="user.avatar_url"
-      @updated="url => user.avatar_url = url"
+      :src="avatarSrc"
+      @updated="handleAvatarUpdated"
     />
 
     <div>
@@ -13,9 +13,22 @@
 </template>
 
 <script setup>
+import { computed, ref, watch } from 'vue'
 import { usePage } from '@inertiajs/vue3'
 import AvatarUploader from '@/Components/AvatarUploader.vue'
 
 const page = usePage()
-const user = page.props.auth.user
+const user = computed(() => page.props.auth.user ?? {})
+const avatarSrc = ref(user.value.avatar_url || '')
+
+watch(
+  () => user.value.avatar_url,
+  value => {
+    avatarSrc.value = value || ''
+  }
+)
+
+function handleAvatarUpdated(url) {
+  avatarSrc.value = url
+}
 </script>

--- a/resources/js/Pages/Profile/Partials/ProfileHeader.vue
+++ b/resources/js/Pages/Profile/Partials/ProfileHeader.vue
@@ -2,7 +2,6 @@
   <div class="flex items-center space-x-4">
     <AvatarUploader
       :src="user.avatar_url"
-      :user-id="user.id"
       @updated="url => user.avatar_url = url"
     />
 

--- a/resources/js/Pages/Profile/Partials/ProfileInformationForm.vue
+++ b/resources/js/Pages/Profile/Partials/ProfileInformationForm.vue
@@ -14,9 +14,18 @@ const form = useForm({
 })
 
 function submitForm() {
-  form.patch(route('profile.update'), {
-    preserveScroll: true,
-  })
+  form
+    .transform(data => ({
+      ...data,
+      current_password: data.current_password || null,
+      password: data.password || null,
+      password_confirmation: data.password_confirmation || null,
+    }))
+    .patch(route('profile.update'), {
+      preserveScroll: true,
+      onSuccess: () =>
+        form.reset('current_password', 'password', 'password_confirmation'),
+    })
 }
 
 function deleteAccount() {

--- a/routes/web.php
+++ b/routes/web.php
@@ -61,6 +61,7 @@ Route::middleware('auth')->group(function () {
 Route::middleware('auth')->prefix('profile')->name('profile.')->group(function () {
     Route::get('/', [ProfileController::class, 'edit'])->name('edit');
     Route::patch('/', [ProfileController::class, 'update'])->name('update');
+    Route::post('/avatar', [ProfileController::class, 'updateAvatar'])->name('updateAvatar');
     Route::delete('/', [ProfileController::class, 'destroy'])->name('destroy');
 
     Route::get('/2fa/setup', [TwoFactorAuthController::class, 'show'])->name('2fa.setup');


### PR DESCRIPTION
## Summary
- require the current password before allowing profile password changes and persist optional password updates securely
- add avatar upload endpoint, database column, and storage-backed URL sharing for user profile images
- refresh Inertia shared props and Vue components to use the new avatar URL and reset password form fields after saving

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68cdcdf0578483208a9a41459857f6b8