### PR TITLE
Add user profile additional data and address management

### DIFF
--- a/app/Http/Controllers/UserAdditionalDataController.php
+++ b/app/Http/Controllers/UserAdditionalDataController.php
@@ -11,14 +11,20 @@ class UserAdditionalDataController extends Controller
 {
     public function store(AdditionalDataRequest $request): RedirectResponse
     {
-        $request->user()->additionalData()->updateOrCreate([], $request->validated());
+        $additionalData = $request->user()->additionalData()->firstOrNew([]);
+
+        $additionalData->fill($request->validated());
+        $additionalData->save();
 
         return Redirect::route('profile.edit')->with('status', 'additional-data-saved');
     }
 
     public function update(AdditionalDataRequest $request): RedirectResponse
     {
-        $request->user()->additionalData()->updateOrCreate([], $request->validated());
+        $additionalData = $request->user()->additionalData()->firstOrNew([]);
+
+        $additionalData->fill($request->validated());
+        $additionalData->save();
 
         return Redirect::route('profile.edit')->with('status', 'additional-data-updated');
     }

--- a/app/Http/Controllers/UserAdditionalDataController.php
+++ b/app/Http/Controllers/UserAdditionalDataController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\AdditionalDataRequest;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Redirect;
+
+class UserAdditionalDataController extends Controller
+{
+    public function store(AdditionalDataRequest $request): RedirectResponse
+    {
+        $request->user()->additionalData()->updateOrCreate([], $request->validated());
+
+        return Redirect::route('profile.edit')->with('status', 'additional-data-saved');
+    }
+
+    public function update(AdditionalDataRequest $request): RedirectResponse
+    {
+        $request->user()->additionalData()->updateOrCreate([], $request->validated());
+
+        return Redirect::route('profile.edit')->with('status', 'additional-data-updated');
+    }
+
+    public function destroy(Request $request): RedirectResponse
+    {
+        $additionalData = $request->user()->additionalData;
+
+        if ($additionalData) {
+            $additionalData->delete();
+        }
+
+        return Redirect::route('profile.edit')->with('status', 'additional-data-deleted');
+    }
+}

--- a/app/Http/Controllers/UserAddressController.php
+++ b/app/Http/Controllers/UserAddressController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\UserAddressRequest;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Redirect;
+
+class UserAddressController extends Controller
+{
+    public function store(UserAddressRequest $request): RedirectResponse
+    {
+        $request->user()->address()->updateOrCreate([], $request->validated());
+
+        return Redirect::route('profile.edit')->with('status', 'address-saved');
+    }
+
+    public function update(UserAddressRequest $request): RedirectResponse
+    {
+        $request->user()->address()->updateOrCreate([], $request->validated());
+
+        return Redirect::route('profile.edit')->with('status', 'address-updated');
+    }
+
+    public function destroy(Request $request): RedirectResponse
+    {
+        $address = $request->user()->address;
+
+        if ($address) {
+            $address->delete();
+        }
+
+        return Redirect::route('profile.edit')->with('status', 'address-deleted');
+    }
+}

--- a/app/Http/Controllers/UserAddressController.php
+++ b/app/Http/Controllers/UserAddressController.php
@@ -11,14 +11,20 @@ class UserAddressController extends Controller
 {
     public function store(UserAddressRequest $request): RedirectResponse
     {
-        $request->user()->address()->updateOrCreate([], $request->validated());
+        $address = $request->user()->address()->firstOrNew([]);
+
+        $address->fill($request->validated());
+        $address->save();
 
         return Redirect::route('profile.edit')->with('status', 'address-saved');
     }
 
     public function update(UserAddressRequest $request): RedirectResponse
     {
-        $request->user()->address()->updateOrCreate([], $request->validated());
+        $address = $request->user()->address()->firstOrNew([]);
+
+        $address->fill($request->validated());
+        $address->save();
 
         return Redirect::route('profile.edit')->with('status', 'address-updated');
     }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -38,6 +38,7 @@ class HandleInertiaRequests extends Middleware
                 'email' => $request->user()->email,
                 'roles' => $request->user()->getRoleNames()->toArray(),
                 'permissions' => $request->user()->getAllPermissions()->pluck('name')->toArray(),
+                'avatar_url' => $request->user()->avatar_url,
             ] : null,
         ],
     ];

--- a/app/Http/Requests/AdditionalDataRequest.php
+++ b/app/Http/Requests/AdditionalDataRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AdditionalDataRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'cpf' => ['nullable', 'string', 'max:20'],
+            'rg' => ['nullable', 'string', 'max:20'],
+            'birth_date' => ['nullable', 'date'],
+            'phone' => ['nullable', 'string', 'max:30'],
+            'secondary_phone' => ['nullable', 'string', 'max:30'],
+        ];
+    }
+}

--- a/app/Http/Requests/ProfileUpdateRequest.php
+++ b/app/Http/Requests/ProfileUpdateRequest.php
@@ -5,6 +5,7 @@ namespace App\Http\Requests;
 use App\Models\User;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Password;
 
 class ProfileUpdateRequest extends FormRequest
 {
@@ -25,6 +26,17 @@ class ProfileUpdateRequest extends FormRequest
                 'max:255',
                 Rule::unique(User::class)->ignore($this->user()->id),
             ],
+            'current_password' => ['nullable', 'required_with:password', 'current_password'],
+            'password' => ['nullable', 'confirmed', Password::defaults()],
         ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'password' => $this->filled('password') ? $this->password : null,
+            'password_confirmation' => $this->filled('password_confirmation') ? $this->password_confirmation : null,
+            'current_password' => $this->filled('current_password') ? $this->current_password : null,
+        ]);
     }
 }

--- a/app/Http/Requests/UserAddressRequest.php
+++ b/app/Http/Requests/UserAddressRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UserAddressRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'zip_code' => ['nullable', 'string', 'max:20'],
+            'street' => ['nullable', 'string', 'max:150'],
+            'number' => ['nullable', 'string', 'max:20'],
+            'complement' => ['nullable', 'string', 'max:120'],
+            'district' => ['nullable', 'string', 'max:120'],
+            'city' => ['nullable', 'string', 'max:120'],
+            'state' => ['nullable', 'string', 'max:5'],
+            'country' => ['nullable', 'string', 'max:120'],
+            'is_international' => ['required', 'boolean'],
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'is_international' => filter_var($this->input('is_international', false), FILTER_VALIDATE_BOOLEAN),
+        ]);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Minishlink\WebPush\Subscription;
 use Minishlink\WebPush\WebPush;
 use App\Models\PushSubscription;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 /**
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\PushSubscription> $pushSubscriptions
@@ -37,6 +38,7 @@ class User extends Authenticatable implements AuditableContract
         'google2fa_secret',
         'confirmed_2fa',
         'active',
+        'avatar_path',
     ];
 
     /**
@@ -72,6 +74,25 @@ class User extends Authenticatable implements AuditableContract
     public function pushSubscriptions(): HasMany
     {
         return $this->hasMany(PushSubscription::class);
+    }
+
+    public function additionalData(): HasOne
+    {
+        return $this->hasOne(UserAdditionalData::class);
+    }
+
+    public function address(): HasOne
+    {
+        return $this->hasOne(UserAddress::class);
+    }
+
+    public function getAvatarUrlAttribute(): string
+    {
+        if ($this->avatar_path) {
+            return asset('storage/'.$this->avatar_path);
+        }
+
+        return 'https://ui-avatars.com/api/?name=' . urlencode($this->name ?? '');
     }
 
     /**

--- a/app/Models/UserAdditionalData.php
+++ b/app/Models/UserAdditionalData.php
@@ -12,6 +12,7 @@ class UserAdditionalData extends Model
     protected $table = 'user_additional_data';
 
     protected $fillable = [
+        'user_id',
         'cpf',
         'rg',
         'birth_date',

--- a/app/Models/UserAdditionalData.php
+++ b/app/Models/UserAdditionalData.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class UserAdditionalData extends Model
+{
+    use HasFactory;
+
+    protected $table = 'user_additional_data';
+
+    protected $fillable = [
+        'cpf',
+        'rg',
+        'birth_date',
+        'phone',
+        'secondary_phone',
+    ];
+
+    protected $casts = [
+        'birth_date' => 'date',
+    ];
+}

--- a/app/Models/UserAddress.php
+++ b/app/Models/UserAddress.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class UserAddress extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'zip_code',
+        'street',
+        'number',
+        'complement',
+        'district',
+        'city',
+        'state',
+        'country',
+        'is_international',
+    ];
+
+    protected $casts = [
+        'is_international' => 'boolean',
+    ];
+}

--- a/app/Models/UserAddress.php
+++ b/app/Models/UserAddress.php
@@ -10,6 +10,7 @@ class UserAddress extends Model
     use HasFactory;
 
     protected $fillable = [
+        'user_id',
         'zip_code',
         'street',
         'number',

--- a/database/migrations/2025_06_09_000000_add_avatar_path_to_users_table.php
+++ b/database/migrations/2025_06_09_000000_add_avatar_path_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('avatar_path')->nullable()->after('password');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('avatar_path');
+        });
+    }
+};

--- a/database/migrations/2025_06_11_000000_create_user_additional_data_table.php
+++ b/database/migrations/2025_06_11_000000_create_user_additional_data_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('user_additional_data', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('cpf', 20)->nullable();
+            $table->string('rg', 20)->nullable();
+            $table->date('birth_date')->nullable();
+            $table->string('phone', 30)->nullable();
+            $table->string('secondary_phone', 30)->nullable();
+            $table->timestamps();
+
+            $table->unique('user_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('user_additional_data');
+    }
+};

--- a/database/migrations/2025_06_11_000001_create_user_addresses_table.php
+++ b/database/migrations/2025_06_11_000001_create_user_addresses_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('user_addresses', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('zip_code', 20)->nullable();
+            $table->string('street', 150)->nullable();
+            $table->string('number', 20)->nullable();
+            $table->string('complement', 120)->nullable();
+            $table->string('district', 120)->nullable();
+            $table->string('city', 120)->nullable();
+            $table->string('state', 5)->nullable();
+            $table->string('country', 120)->default('Brasil');
+            $table->boolean('is_international')->default(false);
+            $table->timestamps();
+
+            $table->unique('user_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('user_addresses');
+    }
+};

--- a/resources/js/Components/AvatarUploader.vue
+++ b/resources/js/Components/AvatarUploader.vue
@@ -2,8 +2,8 @@
 <template>
   <div class="relative group w-20 h-20">
     <img
-      v-if="src"
-      :src="src"
+      v-if="currentSrc"
+      :src="currentSrc"
       alt="Avatar"
       class="w-full h-full rounded-full object-cover"
     />
@@ -33,19 +33,27 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 // não precisa instalar @inertiajs/inertia: use o router do adapter Vue3
-import { usePage, router as Inertia } from '@inertiajs/vue3'
+import { usePage, router } from '@inertiajs/vue3'
 
 const props = defineProps({
-  src:    { type: String, default: '' },
-  userId: { type: [String, Number], required: true },
+  src: { type: String, default: '' },
 })
 const emit = defineEmits(['updated'])
 
 // pega o nome do usuário via usePage()
 const page = usePage()
 const name = computed(() => page.props.auth.user?.name || '')
+
+const currentSrc = ref(props.src)
+
+watch(
+  () => props.src,
+  value => {
+    currentSrc.value = value
+  }
+)
 
 // monta as iniciais
 const initials = computed(() =>
@@ -68,15 +76,25 @@ function onFileChange(e) {
   const formData = new FormData()
   formData.append('avatar', file)
 
-  Inertia.post(
-    route('profile.updateAvatar', { user: props.userId }),
+  const previewUrl = URL.createObjectURL(file)
+  currentSrc.value = previewUrl
+
+  router.post(
+    route('profile.updateAvatar'),
     formData,
     {
       preserveScroll: true,
+      forceFormData: true,
       onSuccess: page => {
-        // recupera a URL nova do avatar e emite para o pai
         const newUrl = page.props.auth.user.avatar_url
+        currentSrc.value = newUrl
         emit('updated', newUrl)
+      },
+      onFinish: () => {
+        if (fileInput.value) {
+          fileInput.value.value = ''
+        }
+        URL.revokeObjectURL(previewUrl)
       },
     }
   )

--- a/resources/js/Layouts/AdminLayout.vue
+++ b/resources/js/Layouts/AdminLayout.vue
@@ -189,7 +189,7 @@ function defaultTextClass(groupName) {
           <span v-if="!sidebarCollapsed">{{ sidebarCollapsed ? 'Expandir menu' : 'Recolher menu' }}</span>
         </button>
         <div class="flex items-center justify-center">
-          <img class="h-8 w-8 rounded-full" :src="`https://ui-avatars.com/api/?name=${user.name}`" alt="Avatar">
+          <img class="h-8 w-8 rounded-full" :src="user.avatar_url" alt="Avatar">
           <div v-if="!sidebarCollapsed" class="ml-3 text-left">
             <p class="text-sm font-medium text-white">{{ user.name }}</p>
             <p class="text-xs text-blue-custom-400">View profile</p>
@@ -210,7 +210,7 @@ function defaultTextClass(groupName) {
           </button>
           <div class="relative">
             <button @click="dropdownOpen = !dropdownOpen" class="flex items-center space-x-2 focus:outline-none">
-              <img class="h-8 w-8 rounded-full" :src="`https://ui-avatars.com/api/?name=${user.name}`" alt="">
+              <img class="h-8 w-8 rounded-full" :src="user.avatar_url" alt="">
               <span class="hidden md:inline-block text-sm font-medium text-blue-custom-600 dark:text-blue-custom-200">{{ user.name }}</span>
               <i class="fas fa-chevron-down text-xs text-blue-custom-500"></i>
             </button>

--- a/resources/js/Pages/Profile/Edit.vue
+++ b/resources/js/Pages/Profile/Edit.vue
@@ -21,7 +21,11 @@
             </div>
           </template>
           <template #details>
-            <ProfileInformationForm />
+            <div class="space-y-8">
+              <ProfileInformationForm />
+              <AdditionalDataForm :additional-data="props.additionalData" />
+              <AddressForm :address="props.address" />
+            </div>
           </template>
         </CardAccordion>
 
@@ -58,6 +62,8 @@ import AdminLayout from '@/Layouts/AdminLayout.vue'
 import CardAccordion from '@/Components/CardAccordion.vue'
 import { usePage } from '@inertiajs/vue3'
 import ProfileInformationForm from './Partials/ProfileInformationForm.vue'
+import AdditionalDataForm from './Partials/AdditionalDataForm.vue'
+import AddressForm from './Partials/AddressForm.vue'
 import SummaryCard from './Partials/SummaryCard.vue'
 import PrivacyCard from './Partials/PrivacyCard.vue'
 import CommunicationsCard from './Partials/CommunicationsCard.vue'
@@ -66,6 +72,14 @@ import ProfileHeader from './Partials/ProfileHeader.vue'
 const props = defineProps({
   qrCodeUrl: String,
   secretKey: String,
+  additionalData: {
+    type: Object,
+    default: null,
+  },
+  address: {
+    type: Object,
+    default: null,
+  },
 })
 
 const page = usePage()

--- a/resources/js/Pages/Profile/Partials/AdditionalDataForm.vue
+++ b/resources/js/Pages/Profile/Partials/AdditionalDataForm.vue
@@ -19,13 +19,29 @@ const form = useForm({
   secondary_phone: '',
 })
 
+function toDateInputValue(value) {
+  if (!value) return ''
+
+  if (typeof value === 'string') {
+    return value.includes('T') ? value.split('T')[0] : value
+  }
+
+  const date = new Date(value)
+
+  if (Number.isNaN(date.getTime())) {
+    return ''
+  }
+
+  return date.toISOString().slice(0, 10)
+}
+
 watch(
   () => props.additionalData,
   value => {
     form.defaults({
       cpf: value?.cpf ?? '',
       rg: value?.rg ?? '',
-      birth_date: value?.birth_date ?? '',
+      birth_date: toDateInputValue(value?.birth_date),
       phone: value?.phone ?? '',
       secondary_phone: value?.secondary_phone ?? '',
     })
@@ -40,6 +56,9 @@ function submitForm() {
 
   method(route(routeName), {
     preserveScroll: true,
+    onSuccess: () => {
+      form.clearErrors()
+    },
   })
 }
 

--- a/resources/js/Pages/Profile/Partials/AdditionalDataForm.vue
+++ b/resources/js/Pages/Profile/Partials/AdditionalDataForm.vue
@@ -1,0 +1,133 @@
+<script setup>
+import { computed, watch } from 'vue'
+import { router, useForm } from '@inertiajs/vue3'
+
+const props = defineProps({
+  additionalData: {
+    type: Object,
+    default: null,
+  },
+})
+
+const hasRecord = computed(() => Boolean(props.additionalData))
+
+const form = useForm({
+  cpf: '',
+  rg: '',
+  birth_date: '',
+  phone: '',
+  secondary_phone: '',
+})
+
+watch(
+  () => props.additionalData,
+  value => {
+    form.defaults({
+      cpf: value?.cpf ?? '',
+      rg: value?.rg ?? '',
+      birth_date: value?.birth_date ?? '',
+      phone: value?.phone ?? '',
+      secondary_phone: value?.secondary_phone ?? '',
+    })
+    form.reset()
+  },
+  { immediate: true }
+)
+
+function submitForm() {
+  const method = hasRecord.value ? form.put : form.post
+  const routeName = hasRecord.value ? 'profile.additional-data.update' : 'profile.additional-data.store'
+
+  method(route(routeName), {
+    preserveScroll: true,
+  })
+}
+
+function deleteRecord() {
+  if (!hasRecord.value) return
+
+  if (confirm('Deseja remover os dados adicionais?')) {
+    router.delete(route('profile.additional-data.destroy'), {
+      preserveScroll: true,
+      onFinish: () => {
+        form.reset()
+        form.clearErrors()
+      },
+    })
+  }
+}
+</script>
+
+<template>
+  <div class="mt-6 border-t pt-6 space-y-6">
+    <div class="flex items-center justify-between">
+      <h2 class="text-lg font-semibold text-blue-custom-800">Dados adicionais</h2>
+      <button
+        v-if="hasRecord"
+        type="button"
+        @click="deleteRecord"
+        class="text-sm text-red-600 hover:text-red-700"
+      >
+        Remover
+      </button>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div>
+        <label class="block text-sm font-medium text-gray-700">CPF</label>
+        <input
+          type="text"
+          v-model="form.cpf"
+          class="mt-1 block w-full border-gray-300 rounded-md shadow-sm"
+        />
+        <p v-if="form.errors.cpf" class="text-sm text-red-600 mt-1">{{ form.errors.cpf }}</p>
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-gray-700">RG</label>
+        <input
+          type="text"
+          v-model="form.rg"
+          class="mt-1 block w-full border-gray-300 rounded-md shadow-sm"
+        />
+        <p v-if="form.errors.rg" class="text-sm text-red-600 mt-1">{{ form.errors.rg }}</p>
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-gray-700">Data de nascimento</label>
+        <input
+          type="date"
+          v-model="form.birth_date"
+          class="mt-1 block w-full border-gray-300 rounded-md shadow-sm"
+        />
+        <p v-if="form.errors.birth_date" class="text-sm text-red-600 mt-1">{{ form.errors.birth_date }}</p>
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-gray-700">Telefone principal</label>
+        <input
+          type="text"
+          v-model="form.phone"
+          class="mt-1 block w-full border-gray-300 rounded-md shadow-sm"
+        />
+        <p v-if="form.errors.phone" class="text-sm text-red-600 mt-1">{{ form.errors.phone }}</p>
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-gray-700">Telefone secundário</label>
+        <input
+          type="text"
+          v-model="form.secondary_phone"
+          class="mt-1 block w-full border-gray-300 rounded-md shadow-sm"
+        />
+        <p v-if="form.errors.secondary_phone" class="text-sm text-red-600 mt-1">{{ form.errors.secondary_phone }}</p>
+      </div>
+    </div>
+
+    <div>
+      <button
+        type="button"
+        @click="submitForm"
+        class="bg-blue-custom-600 hover:bg-blue-custom-800 text-white font-semibold px-4 py-2 rounded"
+      >
+        Salvar dados
+      </button>
+    </div>
+  </div>
+</template>

--- a/resources/js/Pages/Profile/Partials/AddressForm.vue
+++ b/resources/js/Pages/Profile/Partials/AddressForm.vue
@@ -35,7 +35,7 @@ watch(
       city: value?.city ?? '',
       state: value?.state ?? '',
       country: value?.country ?? 'Brasil',
-      is_international: false,
+      is_international: Boolean(value?.is_international ?? false),
     })
     form.reset()
   },

--- a/resources/js/Pages/Profile/Partials/AddressForm.vue
+++ b/resources/js/Pages/Profile/Partials/AddressForm.vue
@@ -35,7 +35,7 @@ watch(
       city: value?.city ?? '',
       state: value?.state ?? '',
       country: value?.country ?? 'Brasil',
-      is_international: value?.is_international ?? false,
+      is_international: false,
     })
     form.reset()
   },
@@ -78,32 +78,6 @@ function deleteRecord() {
       >
         Remover
       </button>
-    </div>
-
-    <div class="flex items-center gap-4">
-      <label class="text-sm font-medium text-gray-700">Localização</label>
-      <div class="inline-flex rounded-md shadow-sm" role="group">
-        <button
-          type="button"
-          :class="[
-            'px-3 py-1 border border-gray-300 text-sm font-medium rounded-l-md',
-            !form.is_international ? 'bg-blue-custom-600 text-white' : 'bg-white text-gray-700',
-          ]"
-          @click="form.is_international = false"
-        >
-          Moro no Brasil
-        </button>
-        <button
-          type="button"
-          :class="[
-            'px-3 py-1 border border-gray-300 text-sm font-medium rounded-r-md',
-            form.is_international ? 'bg-blue-custom-600 text-white' : 'bg-white text-gray-700',
-          ]"
-          @click="form.is_international = true"
-        >
-          Moro no exterior
-        </button>
-      </div>
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4">

--- a/resources/js/Pages/Profile/Partials/AddressForm.vue
+++ b/resources/js/Pages/Profile/Partials/AddressForm.vue
@@ -1,0 +1,162 @@
+<script setup>
+import { computed, watch } from 'vue'
+import { router, useForm } from '@inertiajs/vue3'
+
+const props = defineProps({
+  address: {
+    type: Object,
+    default: null,
+  },
+})
+
+const hasRecord = computed(() => Boolean(props.address))
+
+const form = useForm({
+  zip_code: '',
+  street: '',
+  number: '',
+  complement: '',
+  district: '',
+  city: '',
+  state: '',
+  country: 'Brasil',
+  is_international: false,
+})
+
+watch(
+  () => props.address,
+  value => {
+    form.defaults({
+      zip_code: value?.zip_code ?? '',
+      street: value?.street ?? '',
+      number: value?.number ?? '',
+      complement: value?.complement ?? '',
+      district: value?.district ?? '',
+      city: value?.city ?? '',
+      state: value?.state ?? '',
+      country: value?.country ?? 'Brasil',
+      is_international: value?.is_international ?? false,
+    })
+    form.reset()
+  },
+  { immediate: true }
+)
+
+function submitForm() {
+  const method = hasRecord.value ? form.put : form.post
+  const routeName = hasRecord.value ? 'profile.address.update' : 'profile.address.store'
+
+  method(route(routeName), {
+    preserveScroll: true,
+  })
+}
+
+function deleteRecord() {
+  if (!hasRecord.value) return
+
+  if (confirm('Deseja remover o endereço?')) {
+    router.delete(route('profile.address.destroy'), {
+      preserveScroll: true,
+      onFinish: () => {
+        form.reset()
+        form.clearErrors()
+      },
+    })
+  }
+}
+</script>
+
+<template>
+  <div class="mt-6 border-t pt-6 space-y-6">
+    <div class="flex items-center justify-between">
+      <h2 class="text-lg font-semibold text-blue-custom-800">Endereço</h2>
+      <button
+        v-if="hasRecord"
+        type="button"
+        @click="deleteRecord"
+        class="text-sm text-red-600 hover:text-red-700"
+      >
+        Remover
+      </button>
+    </div>
+
+    <div class="flex items-center gap-4">
+      <label class="text-sm font-medium text-gray-700">Localização</label>
+      <div class="inline-flex rounded-md shadow-sm" role="group">
+        <button
+          type="button"
+          :class="[
+            'px-3 py-1 border border-gray-300 text-sm font-medium rounded-l-md',
+            !form.is_international ? 'bg-blue-custom-600 text-white' : 'bg-white text-gray-700',
+          ]"
+          @click="form.is_international = false"
+        >
+          Moro no Brasil
+        </button>
+        <button
+          type="button"
+          :class="[
+            'px-3 py-1 border border-gray-300 text-sm font-medium rounded-r-md',
+            form.is_international ? 'bg-blue-custom-600 text-white' : 'bg-white text-gray-700',
+          ]"
+          @click="form.is_international = true"
+        >
+          Moro no exterior
+        </button>
+      </div>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div>
+        <label class="block text-sm font-medium text-gray-700">CEP</label>
+        <input v-model="form.zip_code" type="text" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" />
+        <p v-if="form.errors.zip_code" class="text-sm text-red-600 mt-1">{{ form.errors.zip_code }}</p>
+      </div>
+      <div class="md:col-span-2">
+        <label class="block text-sm font-medium text-gray-700">Rua</label>
+        <input v-model="form.street" type="text" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" />
+        <p v-if="form.errors.street" class="text-sm text-red-600 mt-1">{{ form.errors.street }}</p>
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-gray-700">Número</label>
+        <input v-model="form.number" type="text" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" />
+        <p v-if="form.errors.number" class="text-sm text-red-600 mt-1">{{ form.errors.number }}</p>
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-gray-700">Complemento</label>
+        <input v-model="form.complement" type="text" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" />
+        <p v-if="form.errors.complement" class="text-sm text-red-600 mt-1">{{ form.errors.complement }}</p>
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-gray-700">Bairro</label>
+        <input v-model="form.district" type="text" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" />
+        <p v-if="form.errors.district" class="text-sm text-red-600 mt-1">{{ form.errors.district }}</p>
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-gray-700">Cidade</label>
+        <input v-model="form.city" type="text" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" />
+        <p v-if="form.errors.city" class="text-sm text-red-600 mt-1">{{ form.errors.city }}</p>
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-gray-700">Estado</label>
+        <input v-model="form.state" type="text" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" />
+        <p v-if="form.errors.state" class="text-sm text-red-600 mt-1">{{ form.errors.state }}</p>
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-gray-700">País</label>
+        <input v-model="form.country" type="text" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" />
+        <p v-if="form.errors.country" class="text-sm text-red-600 mt-1">{{ form.errors.country }}</p>
+      </div>
+    </div>
+
+    <div>
+      <button
+        type="button"
+        @click="submitForm"
+        class="bg-blue-custom-600 hover:bg-blue-custom-800 text-white font-semibold px-4 py-2 rounded"
+      >
+        Salvar endereço
+      </button>
+    </div>
+  </div>
+</template>

--- a/resources/js/Pages/Profile/Partials/ProfileHeader.vue
+++ b/resources/js/Pages/Profile/Partials/ProfileHeader.vue
@@ -1,9 +1,8 @@
 <template>
   <div class="flex items-center space-x-4">
     <AvatarUploader
-      :src="user.avatar_url"
-      :user-id="user.id"
-      @updated="url => user.avatar_url = url"
+      :src="avatarSrc"
+      @updated="handleAvatarUpdated"
     />
 
     <div>
@@ -14,9 +13,22 @@
 </template>
 
 <script setup>
+import { computed, ref, watch } from 'vue'
 import { usePage } from '@inertiajs/vue3'
 import AvatarUploader from '@/Components/AvatarUploader.vue'
 
 const page = usePage()
-const user = page.props.auth.user
+const user = computed(() => page.props.auth.user ?? {})
+const avatarSrc = ref(user.value.avatar_url || '')
+
+watch(
+  () => user.value.avatar_url,
+  value => {
+    avatarSrc.value = value || ''
+  }
+)
+
+function handleAvatarUpdated(url) {
+  avatarSrc.value = url
+}
 </script>

--- a/resources/js/Pages/Profile/Partials/ProfileInformationForm.vue
+++ b/resources/js/Pages/Profile/Partials/ProfileInformationForm.vue
@@ -14,9 +14,18 @@ const form = useForm({
 })
 
 function submitForm() {
-  form.patch(route('profile.update'), {
-    preserveScroll: true,
-  })
+  form
+    .transform(data => ({
+      ...data,
+      current_password: data.current_password || null,
+      password: data.password || null,
+      password_confirmation: data.password_confirmation || null,
+    }))
+    .patch(route('profile.update'), {
+      preserveScroll: true,
+      onSuccess: () =>
+        form.reset('current_password', 'password', 'password_confirmation'),
+    })
 }
 
 function deleteAccount() {

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,8 @@ use App\Http\Controllers\{
     PushSubscriptionController,
     DashboardController,
     PublicSearchController,
+    UserAdditionalDataController,
+    UserAddressController,
 };
 
 Route::get('/welcome', function () {
@@ -61,7 +63,16 @@ Route::middleware('auth')->group(function () {
 Route::middleware('auth')->prefix('profile')->name('profile.')->group(function () {
     Route::get('/', [ProfileController::class, 'edit'])->name('edit');
     Route::patch('/', [ProfileController::class, 'update'])->name('update');
+    Route::post('/avatar', [ProfileController::class, 'updateAvatar'])->name('updateAvatar');
     Route::delete('/', [ProfileController::class, 'destroy'])->name('destroy');
+
+    Route::post('/additional-data', [UserAdditionalDataController::class, 'store'])->name('additional-data.store');
+    Route::put('/additional-data', [UserAdditionalDataController::class, 'update'])->name('additional-data.update');
+    Route::delete('/additional-data', [UserAdditionalDataController::class, 'destroy'])->name('additional-data.destroy');
+
+    Route::post('/address', [UserAddressController::class, 'store'])->name('address.store');
+    Route::put('/address', [UserAddressController::class, 'update'])->name('address.update');
+    Route::delete('/address', [UserAddressController::class, 'destroy'])->name('address.destroy');
 
     Route::get('/2fa/setup', [TwoFactorAuthController::class, 'show'])->name('2fa.setup');
     Route::post('/2fa/enable', [TwoFactorAuthController::class, 'enable'])->name('2fa.enable');


### PR DESCRIPTION
## Summary
- load user additional data and addresses in the profile view and expose dedicated profile routes for managing them
- create models, requests, and migrations to persist per-user additional information and addresses
- extend the profile accordion with Vue forms to create, update, and remove additional data and address records

## Testing
- php artisan test *(fails: vendor directory with Composer dependencies is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdcdf0578483208a9a41459857f6b8